### PR TITLE
Bump core and FPU interco

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -22,12 +22,12 @@ dependencies:
   icache_mp_128_pf:       { git: "https://github.com/pulp-platform/icache_mp_128_pf.git", rev: "6f2e54102001230db9c82432bf9e011842419a48" }
   icache_private:         { git: "https://github.com/AlSaqr-platform/icache_private.git", rev: "84436443d3a2dbad0b94a85c2c5cc8915632fd26" }
   cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", version: 2.1.0 }
-  fpu_interco:            { git: "https://github.com/AlSaqr-platform/fpu_interco.git", rev: "8abf4aeef3bcc43e2db553f0c6ed3e733a270218" } # branch: master
+  fpu_interco:            { git: "https://github.com/AlSaqr-platform/fpu_interco.git", rev: "554127b310a89e8ed6a7ea68c56bae09458bdab9" } # branch: master
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: 0.39.1-beta }
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: 1.0.2 }
   common_cells:           { git: "https://github.com/pulp-platform/common_cells.git", version: 1.13.1 }
   tech_cells_generic:     { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.4 }
-  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "2f3f137117c2abcc86d04df267866fe0e0fcd39f"} # branch: shaheen
+  cv32e40p:               { git: "https://github.com/pulp-platform/cv32e40p.git", rev: "f914f3d2fd013a2d2c4c70f7afae3e6592496db7"} # branch: shaheen
   #ibex:                   { git: "https://github.com/lowRISC/ibex.git", rev: "pulpissimo-v6.1.1" }
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: 1.0.1}
   hwpe-datamover-example: { git: "https://github.com/pulp-platform/hwpe-datamover-example.git", version: 1.0.1 }


### PR DESCRIPTION
* Point to cv32e40p with FP32, FP16, FP16ALT and FP8 support enabled on the shaheen branch
* Point to the FPU interco with the updated core reference